### PR TITLE
Add bootstrapping of EMR resources into EKS cluster

### DIFF
--- a/test/e2e/bootstrap_resources.py
+++ b/test/e2e/bootstrap_resources.py
@@ -17,15 +17,14 @@ for them.
 
 from dataclasses import dataclass
 from acktest.bootstrapping import Resources
-from acktest.bootstrapping.iam import Role
-from acktest.bootstrapping.vpc import VPC
+
 from e2e import bootstrap_directory
+from e2e.bootstrappable.eks_cluster import EKSCluster
+from e2e.bootstrappable.emr_eks_cluster import EMREnabledEKSCluster
 
 @dataclass
 class BootstrapResources(Resources):
-    ClusterVPC: VPC
-    ClusterRole: Role
-    NodegroupRole: Role
+    HostCluster: EMREnabledEKSCluster
 
 _bootstrap_resources = None
 

--- a/test/e2e/bootstrap_resources.py
+++ b/test/e2e/bootstrap_resources.py
@@ -19,7 +19,6 @@ from dataclasses import dataclass
 from acktest.bootstrapping import Resources
 
 from e2e import bootstrap_directory
-from e2e.bootstrappable.eks_cluster import EKSCluster
 from e2e.bootstrappable.emr_eks_cluster import EMREnabledEKSCluster
 
 @dataclass

--- a/test/e2e/bootstrappable/emr_eks_cluster.py
+++ b/test/e2e/bootstrappable/emr_eks_cluster.py
@@ -22,7 +22,6 @@ from typing import Union
 from botocore import session
 from awscli.customizations.eks.get_token import STSClientFactory, TokenGenerator
 
-from acktest import resources
 from acktest.aws.identity import get_account_id
 from acktest.bootstrapping import Bootstrappable
 from acktest.bootstrapping.iam import ServiceLinkedRole

--- a/test/e2e/bootstrappable/emr_eks_cluster.py
+++ b/test/e2e/bootstrappable/emr_eks_cluster.py
@@ -1,0 +1,191 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import base64
+import boto3
+import kubernetes
+import tempfile
+import yaml
+
+from dataclasses import dataclass, field
+from typing import Union
+from botocore import session
+from awscli.customizations.eks.get_token import STSClientFactory, TokenGenerator
+
+from acktest import resources
+from acktest.aws.identity import get_account_id
+from acktest.bootstrapping import Bootstrappable
+from acktest.bootstrapping.iam import ServiceLinkedRole
+from acktest.bootstrapping.eks import Cluster as EKSCluster
+
+EMR_K8S_ROLE_NAME = "emr-containers"
+EMR_K8S_USER_NAME = "emr-containers"
+
+AWS_AUTH_NAMESPACE = "kube-system"
+AWS_AUTH_CONFIG_MAP_NAME = "aws-auth"
+
+@dataclass
+class EMREnabledEKSCluster(Bootstrappable):
+    # Inputs
+    name_prefix: str
+    emr_namespace: str
+
+    # Subresources
+    cluster: EKSCluster = field(init=False, default=None)
+    emr_slr: ServiceLinkedRole = field(init=False, default=None)
+
+    # Outputs
+
+    def __post_init__(self):
+        self.cluster = EKSCluster(f'{self.name_prefix}-cluster')
+        self.emr_slr = ServiceLinkedRole("emr-containers.amazonaws.com", "AWSServiceRoleForAmazonEMRContainers")
+
+    @property
+    def eks_client(self):
+        return boto3.client("eks", region_name=self.region)
+
+    @property
+    def eks_resource(self):
+        return boto3.resource("eks", region_name=self.region)
+
+    def _write_cafile(self, data: str) -> tempfile.NamedTemporaryFile:
+        cafile = tempfile.NamedTemporaryFile(delete=False)
+
+        cadata_b64 = data
+        cadata = base64.b64decode(cadata_b64)
+
+        cafile.write(cadata)
+        cafile.flush()
+
+        return cafile
+
+    def _get_eks_token(self, cluster_name: str) -> str:
+        sts_client = STSClientFactory(session.get_session()).get_sts_client()
+        return TokenGenerator(sts_client).get_token(cluster_name)
+
+    def _k8s_api_client(self, endpoint: str, token: str, cafile: str) -> kubernetes.client.CoreV1Api:
+        kconfig = kubernetes.config.kube_config.Configuration(
+            host=endpoint,
+            api_key={'authorization': 'Bearer ' + token}
+        )
+        kconfig.ssl_ca_cert = cafile
+        return kubernetes.client.ApiClient(configuration=kconfig)
+
+    def bootstrap(self):
+        """Creates an EKS cluster and installs the EMR components into it.
+        """
+        super().bootstrap()
+
+        cluster = self.eks_client.describe_cluster(name=self.cluster.name)
+        cluster_endpoint = cluster["cluster"]["endpoint"]
+
+        cert_data = cluster["cluster"]["certificateAuthority"]["data"]
+        ca_file = self._write_cafile(cert_data)
+
+        api_client = self._k8s_api_client(
+            cluster_endpoint,
+            self._get_eks_token(self.cluster.name),
+            ca_file.name,
+        )
+
+        core_v1 = kubernetes.client.CoreV1Api(api_client)
+
+        # Create the EMR namespace
+        namespaces = core_v1.list_namespace()
+        if not any(ns.metadata.name == self.emr_namespace for ns in namespaces.items):
+            emr_ns = kubernetes.client.V1Namespace(metadata=kubernetes.client.V1ObjectMeta(name=self.emr_namespace))
+            core_v1.create_namespace(emr_ns)
+
+        rbac_v1 = kubernetes.client.RbacAuthorizationV1Api(api_client)
+
+        # Create the EMR RBAC
+        roles = rbac_v1.list_namespaced_role(self.emr_namespace)
+        if not any(role.metadata.name == EMR_K8S_ROLE_NAME for role in roles.items):
+            rbac_v1.create_namespaced_role(self.emr_namespace, kubernetes.client.V1Role(
+                metadata=kubernetes.client.V1ObjectMeta(name=EMR_K8S_ROLE_NAME, namespace=self.emr_namespace),
+                rules=[
+                    kubernetes.client.V1PolicyRule(
+                        api_groups=[""],
+                        resources=["namespaces"],
+                        verbs=["get"],
+                    ), 
+                    kubernetes.client.V1PolicyRule(
+                        api_groups=[""],
+                        resources=["serviceaccounts", "services", "configmaps", "events", "pods", "pods/log"],
+                        verbs=["get", "list", "watch", "describe", "create", "edit", "delete", "deletecollection", "annotate", "patch", "label"],
+                    ), 
+                    kubernetes.client.V1PolicyRule(
+                        api_groups=[""],
+                        resources=["secrets"],
+                        verbs=["create", "patch", "delete", "watch"],
+                    ), 
+                    kubernetes.client.V1PolicyRule(
+                        api_groups=["apps"],
+                        resources=["statefulsets", "deployments"],
+                        verbs=["get", "list", "watch", "describe", "create", "edit", "delete", "annotate", "patch", "label"],
+                    ), 
+                    kubernetes.client.V1PolicyRule(
+                        api_groups=["batch"],
+                        resources=["jobs"],
+                        verbs=["get", "list", "watch", "describe", "create", "edit", "delete", "annotate", "patch", "label"],
+                    ), 
+                    kubernetes.client.V1PolicyRule(
+                        api_groups=["extensions"],
+                        resources=["ingresses"],
+                        verbs=["get", "list", "watch", "describe", "create", "edit", "delete", "annotate", "patch", "label"],
+                    ), 
+                    kubernetes.client.V1PolicyRule(
+                        api_groups=["rbac.authorization.k8s.io"],
+                        resources=["roles", "rolebindings"],
+                        verbs=["get", "list", "watch", "describe", "create", "edit", "delete", "deletecollection", "annotate", "patch", "label"],
+                    ), 
+                ]
+            ))
+
+        # Create the role binding
+        bindings = rbac_v1.list_namespaced_role_binding(self.emr_namespace)
+        if not any(binding.metadata.name == EMR_K8S_ROLE_NAME for binding in bindings.items):
+            rbac_v1.create_namespaced_role_binding(self.emr_namespace, kubernetes.client.V1RoleBinding(
+                metadata=kubernetes.client.V1ObjectMeta(name=EMR_K8S_ROLE_NAME, namespace=self.emr_namespace),
+                subjects=[
+                    kubernetes.client.V1Subject(
+                        api_group="rbac.authorization.k8s.io",
+                        kind="User",
+                        name=EMR_K8S_USER_NAME,
+                    )
+                ],
+                role_ref=kubernetes.client.V1RoleRef(kind="Role", name=EMR_K8S_ROLE_NAME, api_group="rbac.authorization.k8s.io")
+            ))
+
+        # Patch the auth configmap
+        current_auth = core_v1.read_namespaced_config_map(AWS_AUTH_CONFIG_MAP_NAME, AWS_AUTH_NAMESPACE)
+        map_roles = current_auth.data["mapRoles"]
+        map_roles = yaml.safe_load(map_roles)
+
+        if not any(role["username"] == EMR_K8S_USER_NAME for role in map_roles):
+            map_roles.append({
+                "rolearn": f"arn:aws:iam::{get_account_id()}:role/{self.emr_slr.role_name}",
+                "username": EMR_K8S_USER_NAME
+            })
+            auth_patch = [{
+                "op": "replace",
+                "path": "/data/mapRoles",
+                "value": yaml.dump(map_roles)
+            }]
+            core_v1.patch_namespaced_config_map(AWS_AUTH_CONFIG_MAP_NAME, AWS_AUTH_NAMESPACE, auth_patch)
+
+    def cleanup(self):
+        """Deletes the EKS cluster and all associated resources.
+        """
+        super().cleanup()
+        

--- a/test/e2e/common/types.py
+++ b/test/e2e/common/types.py
@@ -1,1 +1,0 @@
-CLUSTER_RESOURCE_PLURAL = 'clusters'

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,2 +1,2 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@835781dcbb39e2220e68a659dd771ce4bd9b1ac0
-awscli==1.20.65
+acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@1632c45163c27780be84f045d0eb7fc900f4c88f
+awscli==1.22.101

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,2 @@
 acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@835781dcbb39e2220e68a659dd771ce4bd9b1ac0
+awscli==1.20.65

--- a/test/e2e/resources/simple_cluster.yaml
+++ b/test/e2e/resources/simple_cluster.yaml
@@ -2,7 +2,6 @@ apiVersion: emrcontainers.services.k8s.aws/v1alpha1
 kind: VirtualCluster
 metadata:
   name: $VIRTUALCLUSTER_NAME
-  namespace: $NAMESPACE
 spec:
   name: $VIRTUALCLUSTER_NAME
   containerProvider:
@@ -10,4 +9,4 @@ spec:
     type_: EKS
     info:
       eksInfo:
-        namespace: $NAMESPACE
+        namespace: emr-ns

--- a/test/e2e/service_bootstrap.py
+++ b/test/e2e/service_bootstrap.py
@@ -17,12 +17,10 @@ import logging
 import time
 
 from acktest.bootstrapping import Resources, BootstrapFailureException
-from acktest.bootstrapping.iam import Role
-from acktest.bootstrapping.vpc import VPC
-from acktest.resources import random_suffix_name
-from acktest.aws.identity import get_region
+
 from e2e import bootstrap_directory
-from e2e.bootstrap_resources import BootstrapResources, get_bootstrap_resources
+from e2e.bootstrap_resources import BootstrapResources
+from e2e.bootstrappable.emr_eks_cluster import EMREnabledEKSCluster
 
 # Time to wait after modifying the CR for the status to change
 MODIFY_WAIT_AFTER_SECONDS = 10
@@ -32,16 +30,9 @@ CHECK_STATUS_WAIT_SECONDS = 10
 
 def service_bootstrap() -> Resources:
     logging.getLogger().setLevel(logging.INFO)
-    region = get_region()
 
     resources = BootstrapResources(
-        ClusterRole=Role("cluster-role", "eks.amazonaws.com", managed_policies=["arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"]),
-        NodegroupRole=Role("nodegroup-role", "ec2.amazonaws.com", managed_policies=[
-            "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
-            "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
-            "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
-        ]),
-        ClusterVPC=VPC(name_prefix="cluster-vpc", num_public_subnet=2, num_private_subnet=2),
+        HostCluster=EMREnabledEKSCluster("emr-eks-cluster", "emr-ns")
     )
 
     try:

--- a/test/e2e/tests/test_virtualcluster.py
+++ b/test/e2e/tests/test_virtualcluster.py
@@ -22,14 +22,9 @@ from typing import Dict
 import pytest
 
 from acktest.k8s import resource as k8s
-from acktest.k8s import condition
 from acktest.resources import random_suffix_name
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_eks_resource
-from e2e.common.types import CLUSTER_RESOURCE_PLURAL
 from e2e.replacement_values import REPLACEMENT_VALUES
-from dataclasses import dataclass, field
-# from e2e import bootstrap_directory
-# from e2e.bootstrap_resources import BootstrapResources
 from e2e.bootstrap_resources import get_bootstrap_resources
 
 RESOURCE_PLURAL = "virtualclusters"
@@ -40,97 +35,45 @@ MODIFY_WAIT_AFTER_SECONDS = 10
 # Time to wait after the zone has changed status, for the CR to update
 CHECK_STATUS_WAIT_SECONDS = 10
 
-def wait_for_cluster_active(eks_client, eks_cluster_name):
-    waiter = eks_client.get_waiter('cluster_active')
-    waiter.wait(name=eks_cluster_name)
+@pytest.fixture
+def simple_cluster():
+    virtual_cluster_name = random_suffix_name("emr-virtual-cluster", 32)
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["VIRTUALCLUSTER_NAME"] = virtual_cluster_name
+    replacements["EKS_CLUSTER_NAME"] = get_bootstrap_resources().HostCluster.cluster.name
+
+    resource_data = load_eks_resource(
+        "simple_cluster",
+        additional_replacements=replacements,
+    )
+    logging.debug(resource_data)
+
+    # Create the k8s resource
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+        virtual_cluster_name, namespace="default",
+    )
+    k8s.create_custom_resource(ref, resource_data)
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+
+    assert cr is not None
+    assert k8s.get_resource_exists(ref)
+
+    yield (ref, cr)
+
+    # Try to delete, if doesn't already exist
+    try:
+        _, deleted = k8s.delete_custom_resource(ref, 3, 10)
+        assert deleted
+    except:
+        pass
 
 @service_marker
 @pytest.mark.canary
 class TestVirtualCluster:
-    def test_create_delete_ekscluster(self):
-        eks_client = boto3.client("eks")
-        eks_cluster_name = random_suffix_name("eks-cluster", 32)
-        cluster_role = get_bootstrap_resources().ClusterRole.arn
-        private_subnet_1 = get_bootstrap_resources().ClusterVPC.private_subnets.subnet_ids[0]
-        private_subnet_2 = get_bootstrap_resources().ClusterVPC.private_subnets.subnet_ids[1]
-        k8s_version = "1.20"
+    def test_create_delete_virtualcluster(self, simple_cluster, emrcontainers_client):
+        (ref, cr) = simple_cluster
 
-        # Create Kubernetes cluster.
-        response = eks_client.create_cluster(
-            name=eks_cluster_name,
-            version=k8s_version,
-            roleArn=cluster_role,
-            resourcesVpcConfig={
-                "subnetIds": [private_subnet_1, private_subnet_2]
-            }
-        )
-
-        logging.info(f"Creating EKS Cluster {eks_cluster_name}")
-
-        wait_for_cluster_active(eks_client, eks_cluster_name)
-
-        assert eks_cluster_name is not None
-
-        try:
-            aws_res = eks_client.describe_cluster(name=eks_cluster_name)
-            assert aws_res is not None
-            logging.info(f"EKS Cluster {eks_cluster_name} is active")
-        except eks_client.exceptions.ResourceNotFoundException:
-            pytest.fail(f"Could not find cluster '{eks_cluster_name}' in EKS")
-
-        return eks_cluster_name
-
-    def test_create_delete_virtualcluster(self):
-        eks_cluster_name = self.test_create_delete_ekscluster()
-        namespace_name = "default"
-        emrcontainers_client = boto3.client("emr-containers")
-        print("eks_cluster_name =", eks_cluster_name)
-
-        virtual_cluster_name = random_suffix_name("emr-virtual-cluster", 32)
-
-        replacements = REPLACEMENT_VALUES.copy()
-        replacements["VIRTUALCLUSTER_NAME"] = virtual_cluster_name
-        replacements["EKS_CLUSTER_NAME"] = eks_cluster_name
-        replacements["NAMESPACE"] = namespace_name
-
-        resource_data = load_eks_resource(
-            "virtualcluster",
-            additional_replacements=replacements,
-        )
-        logging.debug(resource_data)
-
-        # Create the k8s resource
-        ref = k8s.CustomResourceReference(
-            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
-            virtual_cluster_name, namespace=namespace_name,
-        )
-        k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
-
-        assert cr is not None
-        assert k8s.get_resource_exists(ref)
-
-        try:
-            _, deleted = k8s.delete_custom_resource(ref, 3, 10)
-            assert deleted
-        except:
-            pass
-
-        virtual_cluster_id = cr["status"]["id"]
-        print("virtual_cluster_id = ", virtual_cluster_id)
-
-        assert virtual_cluster_id
-
-        try:
-            aws_res = emrcontainers_client.describe_virtual_cluster(id=virtual_cluster_id)
-            assert aws_res is not None
-        except emrcontainers_client.exceptions.ResourceNotFoundException:
-            pytest.fail(f"Could not find virtual cluster with ID '{virtual_cluster_id}' in EMR on EKS")
-
-#     def cleanup(self):
-#         """Deletes the EKS cluster.
-#         """
-        super().cleanup()
-
-#         eks = self.ec2_resource.Vpc(self.vpc_id)
-        eks_client.delete()
+        # TODO: Tests go here
+        assert cr


### PR DESCRIPTION
This pull requests creates a new `Bootstrappable` type specifically for the `emrcontainers` controller. It uses my new [EKS `Cluster` bootstrappable](https://github.com/aws-controllers-k8s/test-infra/pull/211) as a subresource, and then generates a token to connect to it before deploying the namespace and RBAC privileges for the emrcontainers service linked role.